### PR TITLE
Lyndvhar World

### DIFF
--- a/_maps/lyndvhar_world.dm
+++ b/_maps/lyndvhar_world.dm
@@ -1,0 +1,1 @@
+#define FORCE_MAP "_maps/lyndvhar_world.json"

--- a/_maps/lyndvhar_world.json
+++ b/_maps/lyndvhar_world.json
@@ -1,0 +1,21 @@
+{
+    "map_name": "lyndvhar_world", 
+    "map_path": "map_files/lyndvhar_world",
+	"map_file": [
+	"lyndvhar_world.dmm",
+	"wretch_fort.dmm"
+	
+	],
+	"traits": [{"Name": "lyndvhar_world", "Up": true}, {"Up": true, "Down": true}, {"Up": true, "Down": true}, {"Up": true, "Down": true},{"Up": true, "Down": true}, {"Down": true},
+	{"Name": "wretch_fort", "Up": true}, {"Up": true, "Down": true}, {"Up": true, "Down": true}, {"Down": true}],
+	
+	"minetype": null,
+	"space_empty_levels": 0,
+	"space_ruin_levels": 0,
+	"shuttles": {
+		"cargo": "cargo_rogue",
+		"ferry": "ferry_base",
+		"whiteship": "whiteship_box",
+		"emergency": "emergency_rogue"
+    }
+}

--- a/_maps/map_files/lyndvhar_world/wretch_fort.dmm
+++ b/_maps/map_files/lyndvhar_world/wretch_fort.dmm
@@ -329,8 +329,8 @@
 /area/rogue/under/cave/inhumen)
 "te" = (
 /obj/structure/fluff/traveltile/wretch{
-	aportalgoesto = "wretchin2";
-	aportalid = "wretchout2"
+	aportalgoesto = "wretchout2";
+	aportalid = "wretchin2"
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/inhumen)

--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 10
-	spawn_positions = 10
+	total_positions = 20
+	spawn_positions = 20
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "A wanderer, not from this region. Whatever led you to this fate is up to the wind to decide, be it that you are fleeing the civil war, looking for work, or otherwise. Whether you will survive the coming week is an altogether different matter entirely- however. The roads have become inhospitable and treacherous to most. You may learn fairly quickly why your destination has become so isolated from everywhere else."
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -3,8 +3,8 @@
 	flag = MERCENARY
 	department_flag = MERCENARIES
 	faction = "Station"
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 10
+	spawn_positions = 10
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_SHUNNED_UP
 	tutorial = "Blood stains your hands and the coins you hold. You are a sell-sword, a mercenary, a contractor of war. Where you come from, what you are, who you serve.. none of it matters. What matters is that the mammon flows to your pocket."

--- a/code/modules/roguetown/mapgen/beach.dm
+++ b/code/modules/roguetown/mapgen/beach.dm
@@ -1,8 +1,8 @@
 
 /obj/effect/landmark/mapGenerator/rogue/beach
 	mapGeneratorType = /datum/mapGenerator/beach
-	endTurfX = 128
-	endTurfY = 128
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/code/modules/roguetown/mapgen/bog.dm
+++ b/code/modules/roguetown/mapgen/bog.dm
@@ -1,7 +1,7 @@
 //genstuff
 /obj/effect/landmark/mapGenerator/rogue/bog
 	mapGeneratorType = /datum/mapGenerator/bog
-	endTurfX = 255
+	endTurfX = 450
 	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1

--- a/code/modules/roguetown/mapgen/cavefloor.dm
+++ b/code/modules/roguetown/mapgen/cavefloor.dm
@@ -1,8 +1,8 @@
 
 /obj/effect/landmark/mapGenerator/rogue/cave
 	mapGeneratorType = /datum/mapGenerator/cave
-	endTurfX = 128
-	endTurfY = 128
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 
@@ -39,8 +39,8 @@
 
 /obj/effect/landmark/mapGenerator/rogue/cave/spider
 	mapGeneratorType = /datum/mapGenerator/cave/spider
-	endTurfX = 64
-	endTurfY = 64
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/code/modules/roguetown/mapgen/decap.dm
+++ b/code/modules/roguetown/mapgen/decap.dm
@@ -1,8 +1,8 @@
 //genstuff
 /obj/effect/landmark/mapGenerator/rogue/decap
 	mapGeneratorType = /datum/mapGenerator/decap
-	endTurfX = 255
-	endTurfY = 255
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/code/modules/roguetown/mapgen/forest.dm
+++ b/code/modules/roguetown/mapgen/forest.dm
@@ -1,8 +1,8 @@
 //genstuff
 /obj/effect/landmark/mapGenerator/rogue/forest
 	mapGeneratorType = /datum/mapGenerator/forest
-	endTurfX = 255
-	endTurfY = 255
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/code/modules/roguetown/mapgen/mountains.dm
+++ b/code/modules/roguetown/mapgen/mountains.dm
@@ -1,8 +1,8 @@
 
 /obj/effect/landmark/mapGenerator/rogue/mountain
 	mapGeneratorType = /datum/mapGenerator/mtn
-	endTurfX = 255
-	endTurfY = 255
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/code/modules/roguetown/mapgen/rogueoutdoors.dm
+++ b/code/modules/roguetown/mapgen/rogueoutdoors.dm
@@ -1,7 +1,7 @@
 /obj/effect/landmark/mapGenerator/rogue/roguetownfield
 	mapGeneratorType = /datum/mapGenerator/roguetownfield
-	endTurfX = 155
-	endTurfY = 155
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/code/modules/roguetown/mapgen/underdark.dm
+++ b/code/modules/roguetown/mapgen/underdark.dm
@@ -1,7 +1,7 @@
 /obj/effect/landmark/mapGenerator/rogue/underdark
 	mapGeneratorType = /datum/mapGenerator/underdark
-	endTurfX = 255
-	endTurfY = 450
+	endTurfX = 450
+	endTurfY = 400
 	startTurfX = 1
 	startTurfY = 1
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -19,7 +19,7 @@ endmap
 map dun_manor
 endmap
 
-map lyndvhar_city
+map lyndvhar_world
 	default
 	votable
 endmap


### PR DESCRIPTION
## About The Pull Request

This PR fully integrates the Lyndvhar World map into the server. This new map features as follows -

Lyndvhar City
The Draguippe Forest
The Terrorbog, completely revamped and remade. (The Undergrove will be coming soon)
The Southern Coastal Region (WIP and to be renamed)
Lilac Bay
Mount Decapitation Forest (completely revamped and remade)
Mount Decapitation Skeletal Outpost (completely revamped and remade)
Mount Decapitation Caldera (completely revamped and remade)
The Drake Boss Fight
The Baroness Boss Fight
Minotaur Boss Fight
Temple of the Shattered God (the final dungeon in original decap)
The Underdark (accessed via the final layer of decap)
Melted Undercity
Zizo Temple
Drow Hamlet
Lich Boss Fight 

There is a LOT more to come, but this is a bulk of the content.

I still have to do map connections, after all.


## Testing Evidence

<img width="690" height="579" alt="image" src="https://github.com/user-attachments/assets/eb8d1d42-9e61-4fdc-b554-7c92fc1284e7" />

A sneak peak shot. I'm currently testing this as you read this to make sure everything works fine.

## Why It's Good For The Game

Combines every single map file into one big map, completely revamps all the previous maps and modernizes them, and gives a lot more to explore. I invented a new type of carpal tunnel making this.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
