### PR TITLE
Celestia

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -64,7 +64,6 @@
 				/obj/item/rogueweapon/scabbard/sheath,
 				/obj/item/storage/belt/rogue/pouch/coins/poor
 				)
-			H.grant_language(/datum/language/celestial)
 
 		if("Zeybek")
 			H.set_blindness(0)
@@ -111,7 +110,7 @@
 				/obj/item/flashlight/flare/torch,
 				/obj/item/storage/belt/rogue/pouch/coins/poor
 				)
-			H.grant_language(/datum/language/celestial)
+
 			var/weapons = list("Shamshir and Javelin","Whips and Knives", "Recurve Bow")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			H.set_blindness(0)

--- a/code/modules/language/roguetown/sandspeak.dm
+++ b/code/modules/language/roguetown/sandspeak.dm
@@ -1,6 +1,6 @@
 /datum/language/celestial
-	name = "Sama'glos"
-	desc = ""
+	name = "Celestia"
+	desc = "A language primarily composed of old syllables and words from before the Bloodwake. Almost exclusively used by members of the Pantheonic Church in sermons, and still used primarily by remaining Aasimar."
 	speech_verb = "says"
 	ask_verb = "asks"
 	exclaim_verb = "yells"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -75,7 +75,7 @@
 
 /datum/species/aasimar/after_creation(mob/living/carbon/C)
 	..()
-	to_chat(C, "<span class='info'>I can speak Celestial with ,c before my speech.</span>")
+	to_chat(C, "<span class='info'>I can speak Celestia with ,c before my speech.</span>")
 
 /datum/species/aasimar/on_species_loss(mob/living/carbon/C)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Makes the "sama'glos" language the Celestia language and exclusive for aasimar. Removes it from zybantine stuff as a result.

The Priest keeps it. Consider it in a way like this worlds "latin".

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Zybantu is going to get its own language. Celestia is the old tongue of ancient times.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
