### PR TITLE
Renovates the Deserters

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -52,8 +52,8 @@
 	..()
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
 	gloves = /obj/item/clothing/gloves/roguetown/leather
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
-	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/warden
 	beltr = /obj/item/quiver/arrows
 	beltl = /obj/item/rogueweapon/huntingknife/idagger

--- a/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
@@ -2,11 +2,9 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 //After the bogfort fell to undead, the remaining guard who didn't flea turned to bandirty. Wellarmed and trained.
 //These guys use alot of iron stuff with small amounts of steel mixed in, not really one for finetuned balance might be too hard or easy idk. Going off vibes atm
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_cloak(mob/living/carbon/human/H)
-	var/random_deserter_cloak = rand(1,3)
+	var/random_deserter_cloak = rand(1,2)
 	switch(random_deserter_cloak)
 		if(1)
-			cloak = /obj/item/clothing/cloak/wardencloak
-		if(2)
 			cloak = /obj/item/clothing/cloak/wickercloak
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
@@ -2,14 +2,12 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 //After the bogfort fell to undead, the remaining guard who didn't flea turned to bandirty. Wellarmed and trained.
 //These guys use alot of iron stuff with small amounts of steel mixed in, not really one for finetuned balance might be too hard or easy idk. Going off vibes atm
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_cloak(mob/living/carbon/human/H)
-	var/random_deserter_cloak = rand(1,4)
+	var/random_deserter_cloak = rand(1,3)
 	switch(random_deserter_cloak)
 		if(1)
 			cloak = /obj/item/clothing/cloak/wardencloak
 		if(2)
 			cloak = /obj/item/clothing/cloak/wickercloak
-		if(3)
-			cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon(mob/living/carbon/human/H)
 	var/random_deserter_weapon = rand(1,3)

--- a/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
@@ -75,14 +75,12 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 			beltr = /obj/item/rogueweapon/scabbard/sword
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_armor_hard(mob/living/carbon/human/H)
-	var/random_deserter_armor_hard = rand(1,3)
+	var/random_deserter_armor_hard = rand(1,2)
 	switch(random_deserter_armor_hard)
 		if(1)
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 		if(2)
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/upgraded
-		if(3)
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/iron
 
 /mob/living/carbon/human/species/human/northern/bog_deserters
 	aggressive=1
@@ -263,8 +261,8 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	//Head Gear
-	neck = /obj/item/clothing/neck/roguetown/leather
-	head = /obj/item/clothing/head/roguetown/roguehood/warden
+	neck = /obj/item/clothing/neck/roguetown/gorget
+	head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
@@ -405,14 +403,14 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 	add_random_deserter_cloak(H)
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/coif/heavypadding
-	head = /obj/item/clothing/head/roguetown/roguehood/warden/antler
+	head = /obj/item/clothing/head/roguetown/helmet/sallet/visored/iron
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
 	//Lower Gear
 	belt = /obj/item/storage/belt/rogue/leather
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	//Weapons
 	add_random_deserter_weapon_hard(H)
 	add_random_deserter_beltl_stuff(H)

--- a/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
@@ -5,11 +5,11 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 	var/random_deserter_cloak = rand(1,4)
 	switch(random_deserter_cloak)
 		if(1)
-			cloak = /obj/item/clothing/cloak/stabard/bog
+			cloak = /obj/item/clothing/cloak/wardencloak
 		if(2)
-			cloak = /obj/item/clothing/cloak/stabard/guard
+			cloak = /obj/item/clothing/cloak/wickercloak
 		if(3)
-			cloak = /obj/item/clothing/suit/roguetown/armor/longcoat/brown
+			cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon(mob/living/carbon/human/H)
 	var/random_deserter_weapon = rand(1,3)
@@ -78,9 +78,9 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 	var/random_deserter_armor_hard = rand(1,3)
 	switch(random_deserter_armor_hard)
 		if(1)
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 		if(2)
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/upgraded
 		if(3)
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/iron
 
@@ -261,17 +261,17 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 	//Chest Gear
 	add_random_deserter_cloak(H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/leather
-	head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
+	head = /obj/item/clothing/head/roguetown/roguehood/warden
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
 	//Lower Gear
 	belt = /obj/item/storage/belt/rogue/leather
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
+	pants =/obj/item/clothing/under/roguetown/trou/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	//Weapons
 	add_random_deserter_weapon(H)
 	add_random_deserter_beltl_stuff(H)
@@ -404,8 +404,8 @@ GLOBAL_LIST_INIT(bog_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt
 	add_random_deserter_armor_hard(H)
 	add_random_deserter_cloak(H)
 	//Head Gear
-	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
-	head = /obj/item/clothing/head/roguetown/helmet/sallet/visored/iron
+	neck = /obj/item/clothing/neck/roguetown/coif/heavypadding
+	head = /obj/item/clothing/head/roguetown/roguehood/warden/antler
 	//wrist Gear
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -129,7 +129,7 @@
 	if(prob(50))//CLOAK
 		cloak = /obj/item/clothing/cloak/wickercloak
 	if(prob(45))//HANDS
-		r_hand = /obj/item/rogueweapon/sword
+		r_hand = /obj/item/rogueweapon/sword/iron
 		if(prob(45))
 			r_hand = /obj/item/rogueweapon/spear
 			if(prob(10))

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -107,7 +107,7 @@
 	if(prob(50))//WRIST
 		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	if(prob(10))//ARMOUR
-		armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	if(prob(50))//SHIRT
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 		if(prob(15))
@@ -115,19 +115,19 @@
 			if(prob(15))
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	if(prob(50))//PANTS
-		pants = /obj/item/clothing/under/roguetown/tights/vagrant
+		pants = /obj/item/clothing/under/roguetown/trou/leather
 		if(prob(25))
 			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 			if(prob(25))
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	if(prob(50))//HEAD
-		head = /obj/item/clothing/neck/roguetown/coif
+		head = /obj/item/clothing/head/roguetown/helmet/sallet/iron
 		if(prob(30))
-			head = /obj/item/clothing/head/roguetown/helmet/kettle
+			head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
 	if(prob(50))
-		neck= /obj/item/clothing/neck/roguetown/chaincoif
+		neck= /obj/item/clothing/neck/roguetown/chaincoif/iron
 	if(prob(50))//CLOAK
-		cloak = /obj/item/clothing/cloak/stabard/bog
+		cloak = /obj/item/clothing/cloak/wickercloak
 	if(prob(45))//HANDS
 		r_hand = /obj/item/rogueweapon/sword
 		if(prob(45))
@@ -151,16 +151,17 @@
 
 /datum/outfit/job/roguetown/npc/skeleton/npc/bogguard/master/pre_equip(mob/living/carbon/human/H)
 	. = ..()
-	head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull
-	gloves = /obj/item/clothing/gloves/roguetown/plate
+	head = /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear
+	mask = /obj/item/clothing/head/roguetown/roguehood/warden/antler
+	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-	cloak = /obj/item/clothing/cloak/stabard/bog
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	cloak = /obj/item/clothing/cloak/wardencloak
+	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/upgraded
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
 	belt = /obj/item/storage/belt/rogue/leather
-	r_hand = /obj/item/rogueweapon/halberd
+	r_hand = /obj/item/rogueweapon/greataxe/steel/doublehead
 	H.STASTR = 18
 	H.STASPD = 10
 	H.STACON = 10

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -106,7 +106,7 @@
 	..()
 	if(prob(50))//WRIST
 		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	if(prob(10))//ARMOUR
+	if(prob(25))//ARMOUR
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	if(prob(50))//SHIRT
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -119,7 +119,7 @@
 		if(prob(25))
 			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 			if(prob(25))
-				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				pants = /obj/item/clothing/under/roguetown/splintlegs/iron
 	if(prob(50))//HEAD
 		head = /obj/item/clothing/head/roguetown/helmet/sallet/iron
 		if(prob(30))

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -130,9 +130,9 @@
 		cloak = /obj/item/clothing/cloak/wickercloak
 	if(prob(50))//HANDS
 		r_hand = /obj/item/rogueweapon/sword/iron
-		if(prob(45))
+		if(prob(40))
 			r_hand = /obj/item/rogueweapon/spear
-			if(prob(5))
+			if(prob(10))
 				r_hand = /obj/item/rogueweapon/mace
 	H.STASTR = rand(15,16)
 	H.STASPD = 8

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -128,11 +128,11 @@
 		neck= /obj/item/clothing/neck/roguetown/chaincoif/iron
 	if(prob(50))//CLOAK
 		cloak = /obj/item/clothing/cloak/wickercloak
-	if(prob(45))//HANDS
+	if(prob(50))//HANDS
 		r_hand = /obj/item/rogueweapon/sword/iron
 		if(prob(45))
 			r_hand = /obj/item/rogueweapon/spear
-			if(prob(10))
+			if(prob(5))
 				r_hand = /obj/item/rogueweapon/mace
 	H.STASTR = rand(15,16)
 	H.STASPD = 8


### PR DESCRIPTION
## About The Pull Request

This makes the Bog Deserter mob into less a "bandit in iron armor" to "failed warden". Adjusts their equipment accordingly- no cloaks, no warden weapons, no warden masks- just a general appearance of one. Changes literally nothing else currently for them.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Giving some hostile NPCs more flavor beyond "this is bandit but a bit stronger". More immersion.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
