### PR TITLE
Player Quality Nerfs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -12,7 +12,7 @@
 	selection_color = JCOLOR_INQUISITION
 	outfit = /datum/outfit/job/roguetown/absolver
 	display_order = JDO_ABSOLVER
-	min_pq = 3 // Low potential for grief. A pacifist by trade. Also needs to know wtf a PSYDON is.
+	min_pq = 0 // Low potential for grief. A pacifist by trade. Also needs to know wtf a PSYDON is.
 	max_pq = null
 	round_contrib_points = 2
 	wanderer_examine = FALSE

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
@@ -12,7 +12,7 @@
 	outfit = null
 	outfit_female = null
 	display_order = JDO_ORTHODOXIST
-	min_pq = 3
+	min_pq = 0
 	max_pq = null
 	round_contrib_points = 2
 	advclass_cat_rolls = list(CTAG_INQUISITION = 20)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -17,7 +17,7 @@
 	display_order = JDO_PURITAN
 	advclass_cat_rolls = list(CTAG_PURITAN = 20)
 	give_bank_account = 35
-	min_pq = 6
+	min_pq = 3
 	max_pq = null
 	round_contrib_points = 3
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -16,7 +16,7 @@
 
 	display_order = JDO_BANDIT
 	announce_latejoin = FALSE
-	min_pq = 5
+	min_pq = 8
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
@@ -14,7 +14,7 @@
 	bypass_jobban = FALSE
 	display_order = JDO_VILLAGER
 	give_bank_account = TRUE
-	min_pq = -15
+	min_pq = -10
 	max_pq = null
 	round_contrib_points = 3
 	wanderer_examine = FALSE

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -12,7 +12,7 @@
 	outfit_female = null
 	display_order = JDO_WRETCH
 	show_in_credits = FALSE
-	min_pq = 10
+	min_pq = 8
 	max_pq = null
 
 	obsfuscated_job = TRUE

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -14,7 +14,7 @@
 
 	display_order = JDO_MONK
 	give_bank_account = TRUE
-	min_pq = 1 //A step above Churchling, should funnel new players to the churchling role to learn miracles at a more sedate pace
+	min_pq = -2
 	max_pq = null
 	round_contrib_points = 3
 

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -9,7 +9,7 @@
 	allowed_races = RACES_SHUNNED_UP
 	allowed_patrons = ALL_DIVINE_PATRONS
 	outfit = /datum/outfit/job/roguetown/templar
-	min_pq = 5
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 2
 	total_positions = 4

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -13,7 +13,7 @@
 	advclass_cat_rolls = list(CTAG_SENESCHAL = 20)
 	display_order = JDO_BUTLER
 	give_bank_account = 30
-	min_pq = 3
+	min_pq = 1
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -15,7 +15,7 @@
 
 	give_bank_account = 40
 	noble_income = 20
-	min_pq = 1 //Probably a bad idea to have a complete newbie advising the monarch
+	min_pq = -2
 	max_pq = null
 	round_contrib_points = 1
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -14,7 +14,7 @@
 	outfit = /datum/outfit/job/roguetown/jester
 	display_order = JDO_JESTER
 	give_bank_account = TRUE
-	min_pq = -5
+	min_pq = -10
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -18,7 +18,7 @@
 	whitelist_req = TRUE
 
 	give_bank_account = 30
-	min_pq = 3
+	min_pq = 2
 	max_pq = null
 	round_contrib_points = 4
 

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -19,7 +19,7 @@
 	advclass_cat_rolls = list(CTAG_WARDEN = 20)
 
 	give_bank_account = 16
-	min_pq = 0
+	min_pq = -5
 	max_pq = null
 	round_contrib_points = 1
 

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -16,7 +16,7 @@
 	announce_latejoin = FALSE
 	outfit = /datum/outfit/job/roguetown/dungeoneer
 	give_bank_account = 25
-	min_pq = 0
+	min_pq = -5
 	max_pq = null
 	round_contrib_points = 1
 

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -17,7 +17,7 @@
 	outfit = /datum/outfit/job/roguetown/squire
 	display_order = JDO_SQUIRE
 	give_bank_account = TRUE
-	min_pq = -5 //squires aren't great but they can do some damage
+	min_pq = -2 //squires aren't great but they can do some damage
 	max_pq = null
 	round_contrib_points = 1
 

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -15,7 +15,7 @@
 	display_order = JDO_VET
 	whitelist_req = TRUE
 	give_bank_account = 35
-	min_pq = 5
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 3
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -10,7 +10,7 @@
 	tutorial = "Blood stains your hands and the coins you hold. You are a sell-sword, a mercenary, a contractor of war. Where you come from, what you are, who you serve.. none of it matters. What matters is that the mammon flows to your pocket."
 	display_order = JDO_MERCENARY
 	selection_color = JCOLOR_MERCENARY
-	min_pq = 2
+	min_pq = 0
 	max_pq = null
 	round_contrib_points = 1
 	outfit = null	//Handled by classes

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -18,7 +18,7 @@
 
 	give_bank_account = 40
 	noble_income = 20
-	min_pq = 7
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_knight.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -18,7 +18,7 @@
 
 	give_bank_account = 26
 	noble_income = 16
-	min_pq = 12
+	min_pq = 5
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_captain.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -15,7 +15,7 @@
 	whitelist_req = TRUE
 	give_bank_account = 44
 	noble_income = 22
-	min_pq = 7
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_hand.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -17,7 +17,7 @@
 
 	give_bank_account = 22
 	noble_income = 10
-	min_pq = 8
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 3
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	display_order = JDO_LORD
 	tutorial = "At one point you were merely a vassal to the Ruby Throne, given special status and overseen by the Empress herself. However since her death there has been almost no communication outside of the city. You have had to take increasing amounts of autocratic power in order to sustain your port, so much so that many see you as effectively a lord in your own right. And many want to take this from you, or use it to their advantage- keep your family alive and your power secure, and Lyndvhar may live to see another dae."
 	whitelist_req = FALSE
-	min_pq = 10
+	min_pq = 0
 	max_pq = null
 	round_contrib_points = 5
 	give_bank_account = 1000

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -13,7 +13,7 @@
 	outfit = /datum/outfit/job/roguetown/steward
 	give_bank_account = 22
 	noble_income = 16
-	min_pq = 3
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 4
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
@@ -16,7 +16,7 @@
 	display_order = JDO_SUITOR
 	give_bank_account = 40
 	noble_income = 20
-	min_pq = 1
+	min_pq = 0
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -19,7 +19,7 @@
 	selection_color = JCOLOR_YEOMAN
 	display_order = JDO_GUILDMASTER
 	give_bank_account = 25
-	min_pq = 2
+	min_pq = 1
 	max_pq = null
 	round_contrib_points = 4
 	cmode_music = 'sound/music/cmode/towner/combat_retired.ogg'

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -15,7 +15,7 @@
 	display_order = JDO_TAILOR
 	outfit = /datum/outfit/job/roguetown/tailor
 	give_bank_account = 16
-	min_pq = 0
+	min_pq = -4
 	max_pq = null
 	round_contrib_points = 4
 	cmode_music = 'sound/music/cmode/towner/combat_towner3.ogg'

--- a/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
@@ -13,7 +13,7 @@
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/elder
 	display_order = JDO_CHIEF
-	min_pq = 2
+	min_pq = 1
 	max_pq = null
 	give_bank_account = 16
 	round_contrib_points = 5

--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -18,7 +18,7 @@
 	display_order = JDO_APOTHECARY
 	give_bank_account = 30
 
-	min_pq = 0
+	min_pq = -2
 	max_pq = null
 	round_contrib_points = 3
 


### PR DESCRIPTION
## About The Pull Request

Massively lowers the PQ requirement for most jobs.

Bandits changed from 5 PQ to 8 PQ. Wretch lowered to 8 PQ.

All jobs are effectively on a 0 to 8PQ scale now. If you somehow go lower than 0, maybe some self-reflection should be in order.

## Why It's Good For The Game

PQ acting as an arbitraty limiter for what jobs can be played works on paper, yes- however currently its just a massive stopgap for people. The highest pop we've reached thus far is 33. Once. If you only get 1 PQ per commend, and theres only 12 concurrent players - after you reach a certain amount of PQ the rest would have to be grinded by RCP. And I don't want to have to force people to grind RCP or *beg* me for PQ. So this is an alternative.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
