### PR TITLE
Cooking over a fire no longer has a burn risk

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -124,21 +124,12 @@
 						foundstab = TRUE
 						break
 				if(foundstab)
-					var/prob2spoil = 33
-					if(user.get_skill_level(/datum/skill/craft/cooking))
-						prob2spoil = 1
 					user.visible_message("<span class='notice'>[user] starts to cook [W] over [src].</span>")
 					for(var/i in 1 to 6)
 						if(do_after(user, 30 / cooktime_divisor, target = src))
 							var/obj/item/reagent_containers/food/snacks/S = W
 							var/obj/item/C
-							if(prob(prob2spoil))
-								user.visible_message("<span class='warning'>[user] burns [S].</span>")
-								if(user.client?.prefs.showrolls)
-									to_chat(user, "<span class='warning'>Critfail... [prob2spoil]%.</span>")
-								C = S.cooking(1000, 1000, null)
-							else
-								C = S.cooking(S.cooktime/4, S.cooktime/4, src)
+							C = S.cooking(S.cooktime/4, S.cooktime/4, src)
 							if(C)
 								user.dropItemToGround(S, TRUE)
 								qdel(S)


### PR DESCRIPTION
## About The Pull Request

This makes it that cooking over a fire source, be it a hearth, brazier, campfire, whatever with a stake, knife and a piece of meat no longer has a failure risk if you don't have cooking skill.

## Testing Evidence

Tested ingame and worked perfectly fine.

## Why It's Good For The Game

I have literally cooked food in real life over a fire like this. It's not hard- and it's not difficult. People who live out in a world like this where they have to be extremely more self-reliant than me would probably have a very good idea on how to not fuck up food and make it inedible just by cooking it over a campfire.

This was a lot easier than just giving every single person novice cooking. Not everyone should be an extraordinary cook, but i'll be damned if people are too stupid to even cook over an open fire. Humans have been doing this since the stone age.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
