### PR TITLE
Rogue Cataphract Fix

### DIFF
--- a/code/modules/roguetown/roguemachine/hoardmaster.dm
+++ b/code/modules/roguetown/roguemachine/hoardmaster.dm
@@ -95,7 +95,7 @@
 			unlocked_cats+="Sellsword"
 		if("Sawbones")
 			unlocked_cats+="Sawbones"
-		if("Hedge Knight")
+		if("Hedge Cataphract")
 			unlocked_cats+="Knight"
 		if("Rogue Mage")
 			unlocked_cats+="Mage"


### PR DESCRIPTION
## About The Pull Request

Makes the bandit shop for Rogue Cataphracts work
Why did this happen? When the class was renamed, the hordemaster string wasnt switched as well
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugs bad
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
