### PR TITLE
Statpack Value Readjustment

### DIFF
--- a/modular_azurepeak/statpacks/agile.dm
+++ b/modular_azurepeak/statpacks/agile.dm
@@ -2,7 +2,7 @@
 /datum/statpack/agile/swift
 	name = "Swift"
 	desc = "With the wind in your hair and trouble at your back, your speed has oft been your salvation."
-	stat_array = list(STAT_SPEED = 2, STAT_WILLPOWER = 1, STAT_STRENGTH = -1, STAT_CONSTITUTION = -1)
+	stat_array = list(STAT_SPEED = 3, STAT_WILLPOWER = 1, STAT_STRENGTH = -1, STAT_CONSTITUTION = -2)
 
 /datum/statpack/agile/hardy
 	name = "Hardy"
@@ -17,12 +17,12 @@
 /datum/statpack/agile/thug
 	name = "Thuggish"
 	desc = "Your robust physique and keen eyes oft been your most valuable friends in such trying times."
-	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = 1, STAT_FORTUNE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1, STAT_SPEED = -1)
+	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = 2, STAT_FORTUNE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1, STAT_SPEED = -1)
 
 /datum/statpack/agile/wary
 	name = "Wary"
 	desc = "Eyes forward, ever and always. A careful course has always seen you through... so far."
-	stat_array = list(STAT_STRENGTH = -1, STAT_PERCEPTION = 2, STAT_CONSTITUTION = -1, STAT_SPEED = 2)
+	stat_array = list(STAT_STRENGTH = -1, STAT_PERCEPTION = 3, STAT_CONSTITUTION = -2, STAT_SPEED = 2)
 
 /datum/statpack/agile/dextrous
 	name = "Dextrous"
@@ -32,4 +32,9 @@
 /datum/statpack/agile/deft
 	name = "Deft"
 	desc = "Being quick on the draw has left you weaker when they live past your first strike."
-	stat_array = list(STAT_PERCEPTION = 1, STAT_SPEED = 1, STAT_WILLPOWER = 1, STAT_STRENGTH = -1)
+	stat_array = list(STAT_PERCEPTION = 1, STAT_SPEED = 1, STAT_WILLPOWER = 2, STAT_STRENGTH = -1)
+
+/datum/statpack/agile/quickwitted
+	name = "Quick-Witted"
+	desc = "A quick wit and quicker yet feet have left you seldom lacking for a retort, verbal or otherwise."
+	stat_array = list(STAT_STRENGTH = -1, STAT_CONSTITUTION = -1, STAT_INTELLIGENCE = 2, STAT_SPEED = 2)

--- a/modular_azurepeak/statpacks/mental.dm
+++ b/modular_azurepeak/statpacks/mental.dm
@@ -2,22 +2,22 @@
 /datum/statpack/mental/scholarly
 	name = "Studious"
 	desc = "Your understanding of the world avails you, more often than not."
-	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_PERCEPTION = 1, STAT_STRENGTH = -1, STAT_WILLPOWER = -1)
+	stat_array =  list(STAT_INTELLIGENCE = 3, STAT_PERCEPTION = 2, STAT_STRENGTH = -1, STAT_WILLPOWER = -2)
 
 /datum/statpack/mental/faithdriven
 	name = "Resolute"
 	desc = "Look ever to the Gods for guidance in these trying times - and so you have, to the exclusion of the world around you."
-	stat_array = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_FORTUNE = -1)
+	stat_array = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 2, STAT_WILLPOWER = 1, STAT_PERCEPTION = -2, STAT_FORTUNE = -1)
 
 /datum/statpack/mental/zealous
 	name = "Zealous"
 	desc = "Faith in something drives your body and mind to match what neither can see."
-	stat_array = list(STAT_STRENGTH = 1, STAT_INTELLIGENCE = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_SPEED = -1)
+	stat_array = list(STAT_STRENGTH = 2, STAT_INTELLIGENCE = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_SPEED = -1)
 
 /datum/statpack/mental/augury
 	name = "Foresighted"
 	desc = "You see what is and what will sometimes be."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_INTELLIGENCE = 1, STAT_STRENGTH = -1, STAT_WILLPOWER = -1)
+	stat_array = list(STAT_PERCEPTION = 3, STAT_INTELLIGENCE = 1, STAT_STRENGTH = -2, STAT_WILLPOWER = -1)
 
 /datum/statpack/mental/adept
 	name = "Adept"
@@ -27,17 +27,17 @@
 /datum/statpack/mental/aware
 	name = "Aware"
 	desc = "Your keen senses have not led you astray."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_SPEED = 1, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -1)
+	stat_array = list(STAT_PERCEPTION = 2, STAT_SPEED = 2, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -2)
 
 /datum/statpack/mental/precise
 	name = "Precise"
 	desc = "You've seen it all. You've heard it all. An eye to the horizon, and an ear to the ground, and the right place to strike."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_STRENGTH = 1, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -1)
+	stat_array = list(STAT_PERCEPTION = 3, STAT_STRENGTH = 1, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -1, STAT_SPEED = -1)
 
 /datum/statpack/mental/diligent
 	name = "Diligent"
 	desc = "You take your time, but you have a lot of it to spare."
-	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_WILLPOWER = 1, STAT_SPEED = -1)
+	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_WILLPOWER = 2, STAT_SPEED = -1)
 
 /datum/statpack/mental/industrious
 	name = "Industrious"

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -3,22 +3,22 @@
 /datum/statpack/physical/trained
 	name = "Trained"
 	desc = "Years honing your physique has left you with a physical edge, but your faculties have been somewhat neglected."
-	stat_array = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
+	stat_array = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 2, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
 
 /datum/statpack/physical/muscular
 	name = "Muscular"
 	desc = "Hard labor has honed you into a mass of sinew - a valuable trait in a world where might makes right."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1, STAT_SPEED = -2)
+	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_PERCEPTION = -2, STAT_SPEED = -2)
 
 /datum/statpack/physical/tactician
 	name = "Alert"
 	desc = "You sharpened both your body and your mind as best you were able, and vigilance has been your reward."
-	stat_array = list(STAT_STRENGTH = 1, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1)
+	stat_array = list(STAT_STRENGTH = 1, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 2, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1)
 
 /datum/statpack/physical/taut
 	name = "Taut"
 	desc = "Wound tight like the limbs of a time-teller, your physicality is poised to strike - or flee - at a moment's notice."
-	stat_array = list(STAT_STRENGTH = 1, STAT_WILLPOWER = 1, STAT_SPEED = 1, STAT_PERCEPTION = -2, STAT_CONSTITUTION = -1)
+	stat_array = list(STAT_STRENGTH = 1, STAT_WILLPOWER = 2, STAT_SPEED = 2, STAT_PERCEPTION = -2, STAT_CONSTITUTION = -3)
 
 /datum/statpack/physical/toil
 	name = "Toil-hardened"
@@ -28,9 +28,15 @@
 /datum/statpack/physical/struggler
 	name = "Struggler"
 	desc = "Lyfe's dealt you a poor hand, so you've opted to simply flip the table instead."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_WILLPOWER = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -2)
+	stat_array = list(STAT_STRENGTH = 3, STAT_CONSTITUTION = 3, STAT_WILLPOWER = 3, STAT_INTELLIGENCE = -4, STAT_PERCEPTION = -4, STAT_FORTUNE = -3)
 
 /datum/statpack/physical/enduring
 	name = "Enduring"
 	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again."
-	stat_array = list(STAT_CONSTITUTION = 3, STAT_WILLPOWER = 3, STAT_SPEED = -4)
+	stat_array = list(STAT_CONSTITUTION = 4, STAT_WILLPOWER = 4, STAT_SPEED = -5)
+
+/datum/statpack/physical/tactician
+	name = "Tactician"
+	desc = "You sharpened both your body and your mind as best you were able, and vigilance has been your reward."
+	stat_array = list(STAT_STRENGTH = 1, STAT_SPEED = 1, STAT_INTELLIGENCE = 2, STAT_CONSTITUTION = -1, STAT_ENDURANCE = -1)
+


### PR DESCRIPTION
## About The Pull Request

Considering this server does not use racial stats, we have to rely on statpacks and the stats of jobs.

This is a slight rehash of what the server used to have with some differences.

Please keep in mind I am not a balance genius. This isn't tested. The server is the testing battleground. Adjust as seen fit in the future. (It is really easy to do..)

## Why It's Good For The Game

A lot of jobs right now have negligible stats or are just straight up 10-11 across the board because they arent accounting for no racial.

This should fix that. It gives some nuance.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
