### PR TITLE
the most controversial change imaginable

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -270,6 +270,7 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/roguetown/adventurer/barbarian/pre_equip(mob/living/carbon/human/H, visualsOnly)


### PR DESCRIPTION
## About The Pull Request

gives barbarians the ability to read

## Testing Evidence

1 line change

## Why It's Good For The Game

The game has changed significantly to the point where not being able to read simply isn't a good idea. The quest system that adventurers interact with involves being able to read contracts. While it's true that you're able to get instructions by opening the scroll, the finer details are very often lost and result in you not being able to find the last mob you're trying to kill.

Also, you literally can't use silverface vendors, which is really fucked up.

Say barbarians not being able to read is 'SOVL' and call it Hugbox and get a free Hakitapost

Technically an Azure port 

<img width="1080" height="195" alt="image" src="https://github.com/user-attachments/assets/8db2412c-dc0a-43b7-9bf3-e4ad0b4a3eb7" />
