### PR TITLE
Stewardry Vendor

### DIFF
--- a/code/modules/roguetown/roguemachine/vendor.dm
+++ b/code/modules/roguetown/roguemachine/vendor.dm
@@ -395,16 +395,25 @@
 
 	update_icon()
 
-/obj/structure/roguemachine/vendor/merchant
-	keycontrol = "merchant"
+/obj/structure/roguemachine/vendor/steward
+	keycontrol = "steward"
 
-/obj/structure/roguemachine/vendor/merchant/Initialize()
+/obj/structure/roguemachine/vendor/steward/Initialize()
 	. = ..()
-	for(var/X in list(/obj/item/roguekey/apartments/stall1,/obj/item/roguekey/apartments/stall2,/obj/item/roguekey/apartments/stall3))
+
+	for (var/X in list(/obj/item/roguekey/apartments/stall3, /obj/item/roguekey/apartments/stall4))
 		var/obj/P = new X(src)
 		held_items[P] = list()
 		held_items[P]["NAME"] = P.name
 		held_items[P]["PRICE"] = 10
+
+// stall 1 and 2 are much nicer stalls in comparison
+	for (var/Y in list(/obj/item/roguekey/apartments/stall1, /obj/item/roguekey/apartments/stall2))
+		var/obj/Q = new Y(src)
+		held_items[Q] = list()
+		held_items[Q]["NAME"] = Q.name
+		held_items[Q]["PRICE"] = 30
+
 	update_icon()
 
 /obj/structure/roguemachine/vendor/stablemaster


### PR DESCRIPTION
## About The Pull Request

Adds a PEDDLER to the Stewardry that already has the keys for the stalls inserted into it for purchase.

## Testing Evidence

Tested locally, works fine.

## Why It's Good For The Game

Theres not been a single steward to do physical transactions in relation to stall keys. Stalls will actually get used this way.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
