### PR TITLE
Azure Donor Disabling + Stealthy Shapeshifting

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
@@ -76,4 +76,4 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor/nightman
 		H.dna.species.soundpack_m = new /datum/voicepack/male/zeth()
 	else if(should_wear_femme_clothes(H))
-		armor = /obj/item/clothing/suit/roguetown/armor/armordress/alt
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/silkydress/nitemaster

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -71,7 +71,7 @@
 
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	H = new(shape,src,caster)
-	shape.name = "[shape] ([caster.real_name])"
+	shape.name = "[shape]"
 
 	clothes_req = FALSE
 	human_req = FALSE

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -536,38 +536,8 @@ GLOBAL_LIST_EMPTY(loadout_items)
 //All these items are stored in the donator_fluff.dm in the azure modular folder for simplicity.
 //All should be subtypes of existing weapons/clothes/armor/gear, whatever, to avoid balance issues I guess. Idk, I'm not your boss.
 
-/datum/loadout_item/donator_plex
-	name = "Donator Kit - Rapier di Aliseo"
-	path = /obj/item/enchantingkit/plexiant
+// /datum/loadout_item/donator_plex Upstream Donor Loadout kept as a template
+//	name = "Donator Kit - Rapier di Aliseo"
+//	path = /obj/item/enchantingkit/plexiant
 	ckeywhitelist = list("plexiant")
-
-/datum/loadout_item/donator_sru
-	name = "Donator Kit - Emerald Dress"
-	path = /obj/item/enchantingkit/srusu
-	ckeywhitelist = list("cheekycrenando")
-
-/datum/loadout_item/donator_strudel
-	name = "Donator Kit - Grenzelhoftian Mage Vest"
-	path = /obj/item/enchantingkit/strudle
-	ckeywhitelist = list("toasterstrudes")
-
-/datum/loadout_item/donator_bat
-	name = "Donator Kit - Handcarved Harp"
-	path = /obj/item/enchantingkit/bat
-	ckeywhitelist = list("kitchifox")
-
-/datum/loadout_item/donator_mansa
-	name = "Donator Kit - Wortträger"
-	path = /obj/item/enchantingkit/ryebread
-	ckeywhitelist = list("pepperoniplayboy")	//Byond maybe doesn't like spaces. If a name has a space, do it as one continious name.
-
-/datum/loadout_item/donator_rebel
-	name = "Donator Kit - Gilded Sallet"
-	path = /obj/item/enchantingkit/rebel
-	ckeywhitelist = list("rebel0")
-
-/datum/loadout_item/donator_zydras
-	name = "Donator Kit - Padded silky dress"
-	path = /obj/item/enchantingkit/zydras
-	ckeywhitelist = list("1ceres")
 

--- a/modular_azurepeak/code/game/objects/items/donator_fluff_items.dm
+++ b/modular_azurepeak/code/game/objects/items/donator_fluff_items.dm
@@ -1,5 +1,5 @@
 //Lazily shoving all donator fluff items in here for now. Feel free to make this a sub-folder or something, I think it's just easier to keep a list here and just modify as needed.
-
+//keeping all of this in here to prevent parity conflicts
 //Plexiant's donator item - rapier
 /obj/item/rogueweapon/sword/rapier/aliseo
 	name = "Rapier di Aliseo"
@@ -55,10 +55,10 @@
 	icon = 'modular_azurepeak/icons/clothing/donor_clothes.dmi'
 	mob_overlay_icon = 'modular_azurepeak/icons/clothing/onmob/donor_clothes.dmi'
 
-//Zydras donator item - merchant dress
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress/zydrasdress //Recolored silky dress
+//Repurposed donor content
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress/nitemaster //Recolored silky dress
 	name = "Gold-Black silky dress"
-	desc = "A gorgeous black and gold dress. It seems the padding was removed."
+	desc = "A gorgeous black and gold dress."
 	icon_state = "zydrasdress"
 	item_state = "zydrasdress"
 	sleevetype = "zydrasdress"

--- a/modular_azurepeak/code/game/objects/items/donator_modkit.dm
+++ b/modular_azurepeak/code/game/objects/items/donator_modkit.dm
@@ -65,4 +65,4 @@
 /obj/item/enchantingkit/zydras
 	name = "'Gold-Black silky dress morphing elixir"
 	target_items = list(/obj/item/clothing/suit/roguetown/shirt/dress/silkydress)
-	result_item = /obj/item/clothing/suit/roguetown/shirt/dress/silkydress/zydrasdress
+	result_item = /obj/item/clothing/suit/roguetown/shirt/dress/silkydress/nitemaster


### PR DESCRIPTION
## About The Pull Request

Removes donor loadouts from Azure Peak
Repurposes 1x Donor Sprite for Female NiteMasters
Shapeshifting is now "Stealthy" and doesnt show the users name.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Someone paying another server and getting unique stuff on OUR server doesnt make sense.
Shapeshifting should be more amusing if you cant differentiate the user from an animal.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
